### PR TITLE
webui: add 'inner' flag to check_hwaddr_flag() calls missing it; also…

### DIFF
--- a/release/src/router/www/Advanced_MultiWAN_Content.asp
+++ b/release/src/router/www/Advanced_MultiWAN_Content.asp
@@ -212,7 +212,7 @@ function validForm(){
 	}	
 	
 	if(document.form.wan_hwaddr_x_now.value.length > 0)
-			if(!check_macaddr(document.form.wan_hwaddr_x_now,check_hwaddr_flag(document.form.wan_hwaddr_x_now))){
+			if(!check_macaddr(document.form.wan_hwaddr_x_now,check_hwaddr_flag(document.form.wan_hwaddr_x_now,'inner'))){
 					document.form.wan_hwaddr_x_now.select();
 					document.form.wan_hwaddr_x_now.focus();
 		 	return false;

--- a/release/src/router/www/Advanced_TOR_Content.asp
+++ b/release/src/router/www/Advanced_TOR_Content.asp
@@ -134,7 +134,7 @@ function addRow(obj){
 		obj.focus();
 		obj.select();
 		return false;
-	}else if (!check_macaddr(obj, check_hwaddr_flag(obj))){
+	}else if (!check_macaddr(obj, check_hwaddr_flag(obj, 'inner'))){
 		obj.focus();
 		obj.select();		
 		return false;

--- a/release/src/router/www/Advanced_WAN_Content.asp
+++ b/release/src/router/www/Advanced_WAN_Content.asp
@@ -557,7 +557,7 @@ function validForm(){
 	}	
 	
 	if(document.form.wan_hwaddr_x.value.length > 0)
-			if(!check_macaddr(document.form.wan_hwaddr_x,check_hwaddr_flag(document.form.wan_hwaddr_x))){
+			if(!check_macaddr(document.form.wan_hwaddr_x,check_hwaddr_flag(document.form.wan_hwaddr_x,'inner'))){
 					document.form.wan_hwaddr_x.select();
 					document.form.wan_hwaddr_x.focus();
 		 	return false;

--- a/release/src/router/www/Advanced_WTFast_Content.asp
+++ b/release/src/router/www/Advanced_WTFast_Content.asp
@@ -473,7 +473,7 @@ function addRule(){
 		change_add_btn(0);
 		return false;
 	}
-	else if(check_macaddr(document.form.clientmac_x_0, check_hwaddr_flag(document.form.clientmac_x_0)) == true){
+	else if(check_macaddr(document.form.clientmac_x_0, check_hwaddr_flag(document.form.clientmac_x_0,'inner')) == true){
 		Object.keys(wtfast_rulelist_array).forEach(function(key){
 			if(wtfast_rulelist_array[key][1].toUpperCase() == mac){
 				alert("<#JS_duplicate#>");

--- a/release/src/router/www/DNSFilter.asp
+++ b/release/src/router/www/DNSFilter.asp
@@ -254,7 +254,7 @@ function addRow_main(upper){
 		return false;
 	}
 
-	if(!check_macaddr(document.form.rule_mac, check_hwaddr_flag(document.form.rule_mac))){
+	if(!check_macaddr(document.form.rule_mac, check_hwaddr_flag(document.form.rule_mac,'inner'))){
 		document.form.rule_mac.focus();
 		document.form.rule_mac.select();
 		return false;


### PR DESCRIPTION
… add it to the WAN page

At least one user reported needing a locally-administrated MAC on
his WAN page's MAC clone field, so revert that Asus change.